### PR TITLE
Switch to `create-expo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you wish to work on your mobile device, go ahead and install [Expo Go](https:
 Let's create a new Expo project:
 
 ```
-pnpm create expo-app --template expo-template-blank-typescript
+pnpm create expo@latest --template expo-template-blank-typescript
 ```
 
 Configuring pnpm to use the hoisted `node_modules` structure, and installing the project's dependencies using `pnpm install --force`.


### PR DESCRIPTION
## Description

We have updated the command to pnpm create expo, as it is more likely to be supported in the future. The change is based on [a tweet from Evan Bacon](https://twitter.com/Baconbrix/status/1652372955450441729). By following this updated guide, you'll be able to create a new React Native app with Expo using a more efficient and future-proof [setup method](https://www.npmjs.com/package/create-expo).