### PR TITLE
Improve generic arg type

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,10 @@ type Guest = {
 const renderItem = (item: { item: Guest }) => <GuestItem guest={item.item} />;
 
 export default function Index() {
-  const { firstName, lastName } = useLocalSearchParams<Pick<Guest, 'firstName' | 'lastName'>>();
+  const { firstName, lastName } = useLocalSearchParams<{
+    firstName?: Guest['firstName'];
+    lastName?: Guest['lastName'];
+  }>();
 
   const [guests, setGuests] = useState([
     {

--- a/guest-list-mobile/app/index.tsx
+++ b/guest-list-mobile/app/index.tsx
@@ -17,7 +17,10 @@ const API_URL = "http://45063d72-10f4-4077-a954-686bc0c70988.id.repl.co"
 const renderItem = (item: { item: Guest }) => <GuestItem guest={item.item} />;
 
 export default function Index() {
-  const { firstName, lastName } = useLocalSearchParams<Pick<Guest, 'firstName' | 'lastName'>>();
+  const { firstName, lastName } = useLocalSearchParams<{
+    firstName?: Guest['firstName'];
+    lastName?: Guest['lastName'];
+  }>();
   
   const [guests, setGuests] = useState<Guest[]>([
   ]);


### PR DESCRIPTION
Improve the type of the generic argument, which was first added in #8 

`firstName` and `lastName` can be `undefined` if they are not sent