### PR TITLE
Add files for typescript-eslint

### DIFF
--- a/guest-list-mobile/tsconfig.json
+++ b/guest-list-mobile/tsconfig.json
@@ -1,6 +1,18 @@
 {
-  "extends": "expo/tsconfig.base",
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "eslint-config-upleveled/tsconfig.base.json",
   "compilerOptions": {
-    "strict": true
-  }
+    "jsx": "react-native",
+    "target": "ESNext"
+  },
+  "include": [
+    "**/.eslintrc.cjs",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.cjs",
+    "**/*.mjs"
+  ],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This prevents errors with `@typescript-eslint/` packages not being able to receive type information from TypeScript

```
pnpm eslint . --max-warnings 0

/home/runner/work/upleveled-react-native-expo/upleveled-react-native-expo/guest-list-mobile/.eslintrc.cjs
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/.eslintrc.cjs` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file

✖ 1 problem (1 error, 0 warnings)
```